### PR TITLE
[Bugfix] Default branch name typo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,23 +2,26 @@
 ## Description
 
 
-## Motivation and Context
+## Motivation and context
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
 
 
 <!--- ## Screenshots (if appropriate): -->
 
-## How Has This Been Tested?
+## How has this been tested?
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
 
-## Checklist:
+## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] All TODOs in the code has been resolved or linked with a proper issue.
-- [ ] Code is (auto)formatted.
-- [ ] Documentation (README/CHANGELOG/Wiki/etc) has been updated.
-- [ ] All automatic checks passed.
+- [ ] All TODOs in the code have been resolved or linked to a proper issue.
+- [ ] Code has been (auto)formatted.
+- [ ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
+- [ ] All automated checks have passed.
+
+---
+Clickup task: [hash](link)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [PR-1](https://github.com/AGH-CEAI/aegis_docker/pull/1) - Initial version of the Aegis development container.
+
 ### Changed
 
 ### Deprecated
@@ -16,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- [PR-2](https://github.com/AGH-CEAI/aegis_docker/pull/1) - Fixed typo with the default branch name
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
         zsh \
         ros-dev-tools && \
     # Setup workspace
-    git clone -b devel https://github.com/AGH-CEAI/aegis_ros.git src/aegis_ros && \
+    git clone -b humble-devel https://github.com/AGH-CEAI/aegis_ros.git src/aegis_ros && \
     vcs import src < src/aegis_ros/aegis/aegis.repos && \
     # Install dependencies
     rosdep update --rosdistro $ROS_DISTRO && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This one-liner fixed a typo with the default development branch in the [aegis_ros repo](https://github.com/AGH-CEAI/aegis_ros).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* The build of the container image fails.

<!--- ## Screenshots (if appropriate): -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually, running the building in the `geonosis` PC.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code has been resolved or linked with a proper issue.
- [x] Code is (auto)formatted.
- [x] Documentation (README/CHANGELOG/Wiki/etc) has been updated.
- [x] All automatic checks passed.
